### PR TITLE
Спрайт сорванного вонтед постера пофикшен

### DIFF
--- a/code/game/objects/effects/decals/contraband.dm
+++ b/code/game/objects/effects/decals/contraband.dm
@@ -55,6 +55,7 @@
 			visible_message("<span class='warning'>[user] rips [src] in a single, decisive motion!</span>" )
 			playsound(src.loc, 'sound/items/poster_ripped.ogg', 100, 1)
 			ruined = 1
+			icon = initial(icon)
 			icon_state = "poster_ripped"
 			name = "ripped poster"
 			desc = "You can't make out anything from the poster's original print. It's ruined."


### PR DESCRIPTION
Для генерации изображения разыскиваемого менялось состояние icon, а потом не возвращалось в исходное.
