### PR TITLE
Diamond walls buff #2

### DIFF
--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -170,7 +170,7 @@
 	// Basic dismantling.
 	if(isnull(construction_stage) || !reinf_material)
 
-		var/cut_delay = 60 - material.cut_delay
+		var/cut_delay = 60 + material.cut_delay
 		var/dismantle_verb
 		var/dismantle_sound
 

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -236,10 +236,13 @@ var/list/name_to_material
 	flags = MATERIAL_UNMELTABLE
 	cut_delay = 60
 	icon_colour = "#00FFE1"
+	integrity = 1000
+	melting_point = 30000
+	explosion_resistance = 200
 	opacity = 0.4
 	shard_type = SHARD_SHARD
 	tableslam_noise = 'sound/effects/Glasshit.ogg'
-	hardness = 100
+	hardness = 200
 	stack_origin_tech = list(TECH_MATERIAL = 6)
 
 /material/gold

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -242,7 +242,7 @@ var/list/name_to_material
 	opacity = 0.4
 	shard_type = SHARD_SHARD
 	tableslam_noise = 'sound/effects/Glasshit.ogg'
-	hardness = 200
+	hardness = 100
 	stack_origin_tech = list(TECH_MATERIAL = 6)
 
 /material/gold


### PR DESCRIPTION
Makes diamond walls almost completely fire-resistant with melting point of 30,000 (which can't normally be achieved in-game). Also makes diamond walls diamond walls, not resprited cotton walls.
UPD: some fixes of wallcut delay. Currently it will make dismantling of diamond walls a bit harder.