### PR TITLE
Materials rework - reflection values

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -50,7 +50,7 @@ var/list/global/wall_cache = list()
 			if(material.reflectance + reinf_material.reflectance > 0)
 				// This copies code from code/modules/mob/living/carbon/human/human_defense.dm mostly.
 				// Reflection chance depends on materials' var 'reflectance'.
-				var/reflectchance = material.reflectance + reinf_material.reflectance - round(Proj.damage/3)
+				var/reflectchance = material.reflectance + reinf_material.reflectance - min(round(Proj.damage/3), 50)
 				if(prob(reflectchance))
 					visible_message("\red <B>\The [Proj] gets reflected by shiny surface of reinforced wall!</B>")
 					// Find a turf near or on the original location to bounce to
@@ -76,7 +76,7 @@ var/list/global/wall_cache = list()
 			if(material.reflectance > 0)
 				// This copies code from code/modules/mob/living/carbon/human/human_defense.dm mostly.
 				// Reflection chance depends on materials' var 'reflectance'.
-				var/reflectchance = material.reflectance - round(Proj.damage/3)
+				var/reflectchance = material.reflectance - min(round(Proj.damage/3), 50)
 				if(prob(reflectchance))
 					visible_message("\red <B>\The [Proj] gets reflected by shiny surface of wall!</B>")
 					// Find a turf near or on the original location to bounce to

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -43,16 +43,14 @@ var/list/global/wall_cache = list()
 	if(!radiate())
 		return PROCESS_KILL
 
-// Makes diamond (plated and reinforced) walls to reflect beam-type projectiles just like ablative armor vests.
-// Also removes damage from ion blasts, because it's ridiculous ICly and quite excessive elseif.
+// Makes walls made from reflective-able materials reflect beam-type projectiles depending on their reflectance value.
 /turf/simulated/wall/bullet_act(var/obj/item/projectile/Proj)
 	if(istype(Proj,/obj/item/projectile/beam))
 		if(reinf_material)
-			if(material.name == MATERIAL_DIAMOND && reinf_material.name == MATERIAL_DIAMOND)
+			if(material.reflectance + reinf_material.reflectance > 0)
 				// This copies code from code/modules/mob/living/carbon/human/human_defense.dm mostly.
-				// Chance of reflect was boosted because it's a hull section of diamond wall reinforced with extra diamonds.
-				// And IMHO reflects beams better than warden's self-made 'ablative armor'
-				var/reflectchance = 100 - round(Proj.damage/3)
+				// Reflection chance depends on materials' var 'reflectance'.
+				var/reflectchance = material.reflectance + reinf_material.reflectance - round(Proj.damage/3)
 				if(prob(reflectchance))
 					visible_message("\red <B>\The [Proj] gets reflected by shiny surface of reinforced diamond wall!</B>")
 					// Find a turf near or on the original location to bounce to
@@ -65,13 +63,42 @@ var/list/global/wall_cache = list()
 						Proj.redirect(new_x, new_y, curloc, src)
 
 					return PROJECTILE_CONTINUE // complete projectile permutation
-				else
-					// Because these are hull sections of diamonds reinforced with diamonds. They can deal with lasers.
-					burn(500)
+				else 
+					if(material.name == MATERIAL_DIAMOND && reinf_material.name == MATERIAL_DIAMOND)
+						// Diamond-walls can deal with laser beams.
+						burn(500)
+					else
+						// Non-diamond walls with positive reflection values deal with laser better than walls with negative.
+						burn(1500)
 			else
 				burn(2000)
 		else
-			burn(2500)
+			if(material.reflectance > 0)
+				// This copies code from code/modules/mob/living/carbon/human/human_defense.dm mostly.
+				// Reflection chance depends on materials' var 'reflectance'.
+				var/reflectchance = material.reflectance - round(Proj.damage/3)
+				if(prob(reflectchance))
+					visible_message("\red <B>\The [Proj] gets reflected by shiny surface of reinforced diamond wall!</B>")
+					// Find a turf near or on the original location to bounce to
+					if(Proj.starting)
+						var/new_x = Proj.starting.x + pick(0, 0, 0, 0, 0, -1, 1, -2, 2)
+						var/new_y = Proj.starting.y + pick(0, 0, 0, 0, 0, -1, 1, -2, 2)
+						var/turf/curloc = get_turf(src)
+	
+						// redirect the projectile
+						Proj.redirect(new_x, new_y, curloc, src)
+
+					return PROJECTILE_CONTINUE // complete projectile permutation
+				else 
+					if(material.name == MATERIAL_DIAMOND)
+						// Diamond-walls can deal with laser beams.
+						burn(1000)
+					else
+						// Non-diamond walls with positive reflection values deal with laser better than walls with negative.
+						burn(2000)
+			else
+				burn(2500)
+				
 	//else if(istype(Proj,/obj/item/projectile/ion))
 	//	burn(500)
 

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -52,7 +52,7 @@ var/list/global/wall_cache = list()
 				// Reflection chance depends on materials' var 'reflectance'.
 				var/reflectchance = material.reflectance + reinf_material.reflectance - round(Proj.damage/3)
 				if(prob(reflectchance))
-					visible_message("\red <B>\The [Proj] gets reflected by shiny surface of reinforced diamond wall!</B>")
+					visible_message("\red <B>\The [Proj] gets reflected by shiny surface of reinforced wall!</B>")
 					// Find a turf near or on the original location to bounce to
 					if(Proj.starting)
 						var/new_x = Proj.starting.x + pick(0, 0, 0, 0, 0, -1, 1, -2, 2)
@@ -78,7 +78,7 @@ var/list/global/wall_cache = list()
 				// Reflection chance depends on materials' var 'reflectance'.
 				var/reflectchance = material.reflectance - round(Proj.damage/3)
 				if(prob(reflectchance))
-					visible_message("\red <B>\The [Proj] gets reflected by shiny surface of reinforced diamond wall!</B>")
+					visible_message("\red <B>\The [Proj] gets reflected by shiny surface of wall!</B>")
 					// Find a turf near or on the original location to bounce to
 					if(Proj.starting)
 						var/new_x = Proj.starting.x + pick(0, 0, 0, 0, 0, -1, 1, -2, 2)

--- a/code/modules/materials/materials.dm
+++ b/code/modules/materials/materials.dm
@@ -95,6 +95,7 @@ var/list/name_to_material
 	var/explosion_resistance = 5 // Only used by walls currently.
 	var/conductive = 1           // Objects with this var add CONDUCTS to flags on spawn.
 	var/list/composite_material  // If set, object matter var will be a list containing these values.
+	var/reflectance = -50    // Defines whether material in walls raises (positive values) or decreases (negative values) reflection chance
 
 	// Placeholder vars for the time being, todo properly integrate windows/light tiles/rods.
 	var/created_window
@@ -229,6 +230,7 @@ var/list/name_to_material
 	stack_origin_tech = list(TECH_MATERIAL = 5)
 	door_icon_base = "stone"
 	grind_to = MATERIAL_URANIUM
+	reflectance = 5
 
 /material/diamond
 	name = MATERIAL_DIAMOND
@@ -244,6 +246,7 @@ var/list/name_to_material
 	tableslam_noise = 'sound/effects/Glasshit.ogg'
 	hardness = 100
 	stack_origin_tech = list(TECH_MATERIAL = 6)
+	reflectance = 50
 
 /material/gold
 	name = MATERIAL_GOLD
@@ -255,6 +258,7 @@ var/list/name_to_material
 	sheet_singular_name = "ingot"
 	sheet_plural_name = "ingots"
 	grind_to = MATERIAL_GOLD
+	reflectance = 5
 
 /material/gold/bronze //placeholder for ashtrays
 	name = MATERIAL_BRONZE
@@ -270,6 +274,7 @@ var/list/name_to_material
 	sheet_singular_name = "ingot"
 	sheet_plural_name = "ingots"
 	grind_to = MATERIAL_SILVER
+	reflectance = 10
 
 /material/phoron
 	name = MATERIAL_PHORON
@@ -284,6 +289,7 @@ var/list/name_to_material
 	sheet_singular_name = "crystal"
 	sheet_plural_name = "crystals"
 	grind_to = MATERIAL_PHORON
+	reflectance = -45
 
 /*
 // Commenting this out while fires are so spectacularly lethal, as I can't seem to get this balanced appropriately.
@@ -332,6 +338,7 @@ var/list/name_to_material
 //	icon_colour = "#666666"
 //	icon_colour = "#777777"
 	icon_colour = "#646262"
+	reflectance = -30
 
 /material/steel/holographic
 	name = "holo" + MATERIAL_STEEL
@@ -354,6 +361,7 @@ var/list/name_to_material
 	hardness = 80
 	weight = 23
 	stack_origin_tech = list(TECH_MATERIAL = 2)
+	reflectance = -20
 	composite_material = list(MATERIAL_STEEL = 3750, "platinum" = 3750) //todo
 
 /material/glass
@@ -367,6 +375,7 @@ var/list/name_to_material
 	tableslam_noise = 'sound/effects/Glasshit.ogg'
 	hardness = 30
 	weight = 15
+	reflectance = 20
 	door_icon_base = "stone"
 	destruction_desc = "shatters"
 	window_options = list("One Direction" = 1, "Full Window" = 4)
@@ -457,6 +466,7 @@ var/list/name_to_material
 	tableslam_noise = 'sound/effects/Glasshit.ogg'
 	hardness = 40
 	weight = 30
+	reflectance = 15
 	stack_origin_tech = list(TECH_MATERIAL = 2)
 	composite_material = list(MATERIAL_STEEL = 1875,MATERIAL_GLASS = 3750)
 	window_options = list("One Direction" = 1, "Full Window" = 4, "Windoor" = 5)
@@ -473,6 +483,7 @@ var/list/name_to_material
 	integrity = 200 // idk why but phoron windows are strong, so.
 	icon_colour = "#FC2BC5"
 	stack_origin_tech = list(TECH_MATERIAL = 4)
+	reflectance = 30
 	created_window = /obj/structure/window/phoronbasic
 	wire_product = null
 	rod_product = /obj/item/stack/material/glass/phoronrglass
@@ -482,6 +493,7 @@ var/list/name_to_material
 	display_name = "reinforced phoron glass"
 	icon_state = "sheet-phoronrglass"
 	stack_origin_tech = list(TECH_MATERIAL = 5)
+	reflectance = 25
 	composite_material = list() //todo
 	created_window = /obj/structure/window/phoronreinforced
 	hardness = 40
@@ -498,6 +510,7 @@ var/list/name_to_material
 	weight = 12
 	melting_point = T0C+371 //assuming heat resistant plastic
 	stack_origin_tech = list(TECH_MATERIAL = 3)
+	reflectance = -10
 
 /material/plastic/holographic
 	name = "holoplastic"
@@ -529,6 +542,7 @@ var/list/name_to_material
 	icon_colour = "#E6C5DE"
 	stack_origin_tech = list(TECH_MATERIAL = 6, TECH_POWER = 6, TECH_MAGNET = 5)
 	grind_to = "hydrogen"
+	reflectance = 0
 
 /material/platinum
 	name = "platinum"
@@ -538,6 +552,7 @@ var/list/name_to_material
 	stack_origin_tech = list(TECH_MATERIAL = 2)
 	sheet_singular_name = "ingot"
 	sheet_plural_name = "ingots"
+	reflectance = 10
 
 /material/iron
 	name = MATERIAL_IRON


### PR DESCRIPTION
Adds 'reflectance' as material var. Defines material's ability to reflect laser-like projectiles.
Makes all walls made of materials with positive summed reflectance reflect 'beam' projectiles with a chance depending on each (both plate and reinforcement) material's reflectance.