### PR TITLE
Metaconverting

### DIFF
--- a/code/game/antagonist/antagonist_factions.dm
+++ b/code/game/antagonist/antagonist_factions.dm
@@ -21,8 +21,11 @@
 	
 	// Prevents meta-using of 'convert' verb in order to indicate antags.
 	if(faction.is_antagonist(player) || player_is_antag(player) || !faction.can_become_antag(player))
+		player.rev_cooldown = world.time+100
 		player << "<span class='danger'>The [src] is trying to force you to join the [faction.faction_descriptor]! With no chance of success, actually.</span>"
-		sleep(5)
+		var/choice = alert(player.current,"Asked by [src]: Do you want to join the [faction.faction_descriptor]?","Join the [faction.faction_descriptor]?","No!","Yes!(no)")
+		if(choice == "No!" || choice == "Yes!(no)")
+			player << "<span class='danger'>You had literally no choice!</span>"
 		src << "<span class='danger'>\The [player.current] does not support the [faction.faction_descriptor]!</span>"
 		log_mode("[key_name(src)] pointlessly attempted to convert [key_name(player.current)].", player.current)
 		return

--- a/code/game/antagonist/antagonist_factions.dm
+++ b/code/game/antagonist/antagonist_factions.dm
@@ -21,7 +21,7 @@
 	
 	// Prevents meta-using of 'convert' verb in order to indicate antags.
 	if(faction.is_antagonist(player) || player_is_antag(player) || !faction.can_become_antag(player))
-		player << "<span class='danger'>The [src] is trying to force you joining [faction.faction_descriptor]! With no chance of success, actually.</span>"
+		player << "<span class='danger'>The [src] is trying to force you to join the [faction.faction_descriptor]! With no chance of success, actually.</span>"
 		sleep(5)
 		src << "<span class='danger'>\The [player.current] does not support the [faction.faction_descriptor]!</span>"
 		log_mode("[key_name(src)] pointlessly attempted to convert [key_name(player.current)].", player.current)

--- a/code/game/antagonist/antagonist_factions.dm
+++ b/code/game/antagonist/antagonist_factions.dm
@@ -13,23 +13,20 @@
 	if(!faction.faction_verb || !faction.faction_descriptor || !faction.faction_verb)
 		return
 
-	if(faction.is_antagonist(player))
-		src << "<span class='warning'>\The [player.current] already serves the [faction.faction_descriptor].</span>"
-		return
-
-	if(player_is_antag(player))
-		src << "<span class='warning'>\The [player.current]'s loyalties seem to be elsewhere...</span>"
-		return
-
-	if(!faction.can_become_antag(player))
-		src << "<span class='warning'>\The [player.current] cannot be \a [faction.faction_role_text]!</span>"
-		return
-
 	if(world.time < player.rev_cooldown)
 		src << "<span class='danger'>You must wait five seconds between attempts.</span>"
 		return
-
+		
 	src << "<span class='danger'>You are attempting to convert \the [player.current]...</span>"
+	
+	// Prevents meta-using of 'convert' verb in order to indicate antags.
+	if(faction.is_antagonist(player) || player_is_antag(player) || !faction.can_become_antag(player))
+		player << "<span class='danger'>The [src] is trying to force you joining [faction.faction_descriptor]! With no chance of success, actually.</span>"
+		sleep(5)
+		src << "<span class='danger'>\The [player.current] does not support the [faction.faction_descriptor]!</span>"
+		log_mode("[key_name(src)] pointlessly attempted to convert [key_name(player.current)].", player.current)
+		return
+
 	log_mode("[key_name(src)] attempted to convert [key_name(player.current)].", player.current)
 
 	player.rev_cooldown = world.time+100

--- a/code/game/antagonist/antagonist_factions.dm
+++ b/code/game/antagonist/antagonist_factions.dm
@@ -17,10 +17,14 @@
 		src << "<span class='danger'>You must wait five seconds between attempts.</span>"
 		return
 		
+	if(faction.is_antagonist(player))
+		src << "<span class='warning'>\The [player.current] already serves the [faction.faction_descriptor].</span>"
+		return
+
 	src << "<span class='danger'>You are attempting to convert \the [player.current]...</span>"
 	
 	// Prevents meta-using of 'convert' verb in order to indicate antags.
-	if(faction.is_antagonist(player) || player_is_antag(player) || !faction.can_become_antag(player))
+	if(player_is_antag(player) || !faction.can_become_antag(player))
 		player.rev_cooldown = world.time+100
 		player << "<span class='danger'>The [src] is trying to force you to join the [faction.faction_descriptor]! With no chance of success, actually.</span>"
 		var/choice = alert(player.current,"Asked by [src]: Do you want to join the [faction.faction_descriptor]?","Join the [faction.faction_descriptor]?","No!","Yes!(no)")

--- a/code/game/antagonist/antagonist_factions.dm
+++ b/code/game/antagonist/antagonist_factions.dm
@@ -21,22 +21,19 @@
 		src << "<span class='warning'>\The [player.current] already serves the [faction.faction_descriptor].</span>"
 		return
 
+	log_mode("[key_name(src)] attempted to convert [key_name(player.current)].", player.current)
 	src << "<span class='danger'>You are attempting to convert \the [player.current]...</span>"
+	player.rev_cooldown = world.time+100
 	
 	// Prevents meta-using of 'convert' verb in order to indicate antags.
 	if(player_is_antag(player) || !faction.can_become_antag(player))
-		player.rev_cooldown = world.time+100
 		player << "<span class='danger'>The [src] is trying to force you to join the [faction.faction_descriptor]! With no chance of success, actually.</span>"
 		var/choice = alert(player.current,"Asked by [src]: Do you want to join the [faction.faction_descriptor]?","Join the [faction.faction_descriptor]?","No!","Yes!(no)")
 		if(choice == "No!" || choice == "Yes!(no)")
 			player << "<span class='danger'>You had literally no choice!</span>"
 		src << "<span class='danger'>\The [player.current] does not support the [faction.faction_descriptor]!</span>"
-		log_mode("[key_name(src)] pointlessly attempted to convert [key_name(player.current)].", player.current)
 		return
-
-	log_mode("[key_name(src)] attempted to convert [key_name(player.current)].", player.current)
-
-	player.rev_cooldown = world.time+100
+	
 	var/choice = alert(player.current,"Asked by [src]: Do you want to join the [faction.faction_descriptor]?","Join the [faction.faction_descriptor]?","No!","Yes!")
 	if(choice == "Yes!" && faction.add_antagonist_mind(player, 0, faction.faction_role_text, faction.faction_welcome))
 		src << "<span class='notice'>\The [player.current] joins the [faction.faction_descriptor]!</span>"


### PR DESCRIPTION
Reworked after BeTeP's issue to prevent further uses of 'convert' verb to indicate other antags.